### PR TITLE
Make COVID-19 policy more understandable / more friendly

### DIFF
--- a/health_and_safety/covid19.rst
+++ b/health_and_safety/covid19.rst
@@ -1,25 +1,18 @@
 COVID-19 Policy
 ===============
 
-This Hacklab policy includes the measures we are actively taking to mitigate the spread of coronavirus and the steps you must follow if you wish to use the Hacklab facilities. The policy also details times when the Hacklab may require to close during the pandemic.
+This Hacklab policy includes the measures we are actively taking to mitigate the spread of coronavirus and the steps you must follow if you wish to use the Hacklab facilities.
 
 You are requested to follow all these rules diligently, to ensure a healthy and safe facility for our community. 
 
-This coronavirus (COVID-19) company policy is subject to regular review and changes with the introduction of additional governmental guidelines. If the policy is updated, the directors will update you as soon as possible by email.
+This coronavirus (COVID-19) policy is subject to regular review and changes. If the policy is updated, the directors will update you as soon as possible by email.
 
-This policy is owned by the Edinburgh Hacklab directors. Please email us with any questions or comments (directors@edinburghhacklab.com)
+This policy is the responsibility of the Edinburgh Hacklab directors. Please email us with any questions or comments (directors@edinburghhacklab.com)
 
-Status
-------
-Edinburgh is currently in Tier 3 and the Hacklab is open to members. The booking system must be used and the instructions in this policy followed.
+Intention
+---------
 
-The majority of Scotland will move to Tier 4 from Midnight on Christmas Day and the Hacklab will be required to fully close until further notice. Due to Christmas, we will close from 00:01 on the 26th December 2020. Members should collect any property they need before this date. Some exceptions apply with approval from the Directors.
-
-Background
-----------
-Edinburgh Hacklab was closed in March 2020 in response to the start of the COVID-19 pandemic in the UK. We are proud to have responded quickly to protect the health of our community and closed well in advance of the government lockdown. During this time, limited access has been maintained for members to work on essential projects including the production of face shields for the NHS.
-
-With the publication of Scottish Government guidance for creative studios (see `https://www.gov.scot/publications/coronavirus-covid-19-creative-studios-and-shared-workspaces/ <https://www.gov.scot/publications/coronavirus-covid-19-creative-studios-and-shared-workspaces/>`_) and the Scottish Tier System, the directors have agreed that it is appropriate to reopen the Hacklab when Edinburgh is in Tier 3 or below. 
+The intention of this policy is first and foremost to protect members by reducing the risk of transmission of COVID-19.
 
 Scope
 -----
@@ -29,13 +22,10 @@ Please note that we cannot completely eliminate the risk from coronavirus, howev
 
 Symptoms of Coronavirus
 -----------------------
-We must be vigilant against the spread of coronavirus. It is important that all Hacklab users are aware of the symptoms of COVID-19. These are:
 
-- A raised temperature - either you feel hot to touch on your chest or back, or a thermometer reads 37.8C or higher
-- A continuous cough - coughing a lot for an hour, or more than three episodes of coughing in 24 hours
-- A loss or change to your sense of smell or taste – you've noticed you cannot smell or taste anything, or things smell or taste different to normal
+NHS Scotland provides a COVID-19 Symptom checker at https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19 <https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19>
 
-If you are experiencing **any** of the above symptoms then **DO NOT VISIT THE HACKLAB** and consult the NHS for advice. A symptom checker is available at `https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19/ <https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19/>`_
+If you or a member of your household are experiencing **any** of the these symptoms then **DO NOT VISIT THE HACKLAB** and consult the NHS for advice.
 
 Core Principles
 ----------------
@@ -68,25 +58,11 @@ The following procedures apply to all users visiting the Hacklab premises. These
 
 Who Can Use The Lab?
 ^^^^^^^^^^^^^^^^^^^^
-The rules for using the lab depend on the local tier applied in Edinburgh.
+The rules for using the lab depend on the local tier applied in Edinburgh: https://www.gov.scot/publications/coronavirus-covid-19-protection-levels/ <https://www.gov.scot/publications/coronavirus-covid-19-protection-levels/>
 
 **At Tier 4:**
 
-The lab will be closed to members as required by law. The Hacklab is not considered a business providing critical national infrastructure and as such is required to close the premises. Members will be removed from the access control system to enforce this. For information on business restrictions, please see `https://www.gov.scot/publications/coronavirus-covid-19-businesses-and-workplaces-that-must-close-and-can-open-at-each-protection-level/ <https://www.gov.scot/publications/coronavirus-covid-19-businesses-and-workplaces-that-must-close-and-can-open-at-each-protection-level/>`_
-
-
-A small number of exceptions apply, although where possible these activities must be carried out from home
-
-- Hacklab management activities (e.g. risk assessment, maintenance, preparation for reopening, cleaning)
-- Production/manufacturing activity (e.g. if the use of the Hacklab provides you with an income and the activity cannot be done elsewhere)
-- Essential vehicle maintenance (e.g. bicycle or car repair)
-- Repair of equipment critical to the basic function of your home (e.g. replacing a plug on your microwave)
-- Recovering property from the storeroom
-- Manufacturing where the critical national infrastructure exemption applies (e.g. volunteering to manufacture face shields)
-
-For clarity, any activities relating to leisure, entertainment or education are not allowed.
-
-If an exception applies, please email the directors for access with details of why you need access and what times would be suitable. We will attempt to accommodate reasonable requests and ensure single occupancy of the rooms you need. The general rules on Tier 3 working (e.g. cleaning, ventilation, masks etc apply).
+The lab will be closed to members.
 
 **At Tier 3:**
 
@@ -98,7 +74,7 @@ If any other non-member requires access, please contact the Hacklab Directors fo
 
 **At Tier 2 and below:**
 
-The Tier 3 policy will be reviewed by directors and relaxation of the rules considered based on the latest guidance and compliance by members. We do not expect to enter this tier until late January/February at the earliest where guidance may change with the emergence of the more virulent strain.
+The Tier 3 policy will be reviewed by directors and relaxation of the rules considered based on the latest guidance.
 
 Before Your Visit
 ^^^^^^^^^^^^^^^^^
@@ -106,19 +82,18 @@ Please plan your visit carefully. As a Hacklab user you are responsible for mana
 
 Rules:
 - You must book your use of the lab before entering the premises
-- Do not attend the Hacklab if you are required to self-isolate or quarantine (e.g. if you or a household member contracts Coronavirus, if contacted by Test and Trace or in the case of returning from travel)
-- Do not use the Hacklab for social meetups or entertaining. Due to the unsupervised nature of the premises, we are applying the guidance for indoor at-home meetings for social activities.
+- Do not attend the Hacklab if you are required to self-isolate or quarantine, or if you believe you are exhibiting symptoms of COVID-19 (e.g. if you or a household member contracts Coronavirus, if contacted by Test and Trace or in the case of returning from travel)
 
 Advice
-- Check the current COVID-19 zones and travel guidance. Travel in and out of Zone 3 or Zone 4 is illegal
-- Consider how you will get to the Hacklab. Walking, cycling or car are lower risk than using public transport
+- Check the current COVID-19 zones and travel guidance
+- Consider how you will get to the Hacklab
 - Plan your work carefully as you must fully clear and tidy your work area before your booking ends
 - Consider bringing extra clothes as the Hacklab can be cold when windows are open for ventilation
-- Bring your own PPE if you have it
+- Bring your own PPE
 
 How To Book
 ^^^^^^^^^^^
-The Hacklab Booking System is available at `https://booking.ehlab.uk/ <https://booking.ehlab.uk/>`_ and you can login with your normal Hacklab username and password. The booking system should be used when Edinburgh is at Tier 3 or below and the Hacklab is open. When the Hacklab is closed in Tier 4, access must be agreed with the Directors.
+The Hacklab Booking System is available at `https://booking.ehlab.uk/ <https://booking.ehlab.uk/>`_ and you can login with your normal Hacklab username and password. 
 
 We have initially set some limits which we will adjust as needed to ensure fairness. If you need to exceed these limits, please email the directors
 

--- a/health_and_safety/covid19.rst
+++ b/health_and_safety/covid19.rst
@@ -5,52 +5,27 @@ This Hacklab policy includes the measures we are actively taking to mitigate the
 
 You are requested to follow all these rules diligently, to ensure a healthy and safe facility for our community. 
 
-This coronavirus (COVID-19) policy is subject to regular review and changes. If the policy is updated, the directors will update you as soon as possible by email.
+This coronavirus (COVID-19) policy is subject to regular review and changes. If the policy is updated, the directors will update you as soon as possible by email to the members' mailing list.
 
-This policy is the responsibility of the Edinburgh Hacklab directors. Please email us with any questions or comments (directors@edinburghhacklab.com)
+This policy is the responsibility of the Edinburgh Hacklab directors. Please email them with any questions or comments at <directors@edinburghhacklab.com>
 
 Intention
 ---------
 
-The intention of this policy is first and foremost to protect members by reducing the risk of transmission of COVID-19.
+The intention of this policy is to protect members by reducing the risk of transmission of COVID-19. The Hacklab has not yet had a COVID-19-related incident, and this policy was written with the intention of continuing that trend. 
 
 Scope
 -----
 This policy applies to all Hacklab users including members, guests, visitors and members of the public. It defines who may use the Hacklab premises and the procedures that must be followed before, during and after your visit to ensure the safety of our community.
 
-Please note that we cannot completely eliminate the risk from coronavirus, however, we are doing all that is reasonably practical to reduce the risk. 
+Please note that we cannot completely eliminate the risk from COVID-19, however, we are doing all that is reasonably practical to reduce the risk. 
 
 Symptoms of Coronavirus
 -----------------------
 
-NHS Scotland provides a COVID-19 Symptom checker at https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19 <https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19>
+NHS Scotland provides a COVID-19 Symptom checker at https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19 <https://www.nhsinform.scot/self-help-guides/self-help-guide-coronavirus-covid-19>. Use this, or other materials provided by NHS Scotland, to keep up-to-date with the latest understood symptoms of COVID-19.
 
-If you or a member of your household are experiencing **any** of the these symptoms then **DO NOT VISIT THE HACKLAB** and consult the NHS for advice.
-
-Core Principles
-----------------
-Our policy is based on the following core principles
-
-- Keep within the law, including closing when required to do so
-- Follow the latest government guidance that applies to creative spaces, studios and technology companies
-- Communicate and follow any requirements imposed by Summerhall
-- Risk assess activities
-- Advise users to keep their use of premises to essential use where possible and encourage "Hacking at Home"
-- Restrict occupancy through the use of a booking system to ensure 2m social distancing at all times
-- Introduce regular cleaning and ensure users maintain a clean and tidy facility
-- Enforce preventative measures (e.g. hand cleaning, mask use etc)
-- Carry out contact tracing should the need arise
-
-What We Are Doing
------------------
-The directors are taking a proactive approach to safety. We
-
-- Have carried out and risk assessments of activities which will be under review
-- Are keeping up to date with guidance
-- Have placed hand sanitiser in all rooms and installed hot water to G1 for hand washing
-- Have setup a booking system to ensure a maximum capacity is maintained
-- Started a regular cleaning contract with Daybreak and have supplied cleaning materials for members
-- Have created this policy for users of the space
+If you, a member of your household, or a member of your support bubble are experiencing **any** of the these symptoms then **DO NOT VISIT THE HACKLAB** and consult the NHS for advice.
 
 COVID-19 Procedures
 -------------------
@@ -62,19 +37,17 @@ The rules for using the lab depend on the local tier applied in Edinburgh: https
 
 **At Tier 4:**
 
-The lab will be closed to members.
+The lab will be closed to members. Access to the lab whilst closed will be considered on a case-by-case basis: Contact the directors to organise this. 
 
 **At Tier 3:**
 
-The Hacklab will only open to members and you must not bring visitors to the Hacklab or allow access to the public. 
+The Hacklab will open to members. 
 
-Where you would otherwise be lone working or require assistance with a project for health and safety reasons (e.g. manual handling) you may bring one member of your household (including any bubble) to assist you. If you require this exemption you must ensure that the household member has read this policy, completes contact tracing and that you book exclusive use of the room you are working.
+Where you would otherwise be lone working or require assistance with a project for health and safety reasons (e.g. manual handling) you may bring one member of your household (including any bubble) to assist you. You must ensure that the household member has read and agreed to this policy, provides contact details (in the instance that contact tracing is required) and that you book exclusive use of the room you are working.
 
-If any other non-member requires access, please contact the Hacklab Directors for approval.
+If a non-member requires access for any other reason, please contact the Hacklab Directors.
 
 **At Tier 2 and below:**
-
-The Tier 3 policy will be reviewed by directors and relaxation of the rules considered based on the latest guidance.
 
 Before Your Visit
 ^^^^^^^^^^^^^^^^^
@@ -93,24 +66,26 @@ Advice
 
 How To Book
 ^^^^^^^^^^^
-The Hacklab Booking System is available at `https://booking.ehlab.uk/ <https://booking.ehlab.uk/>`_ and you can login with your normal Hacklab username and password. 
 
-We have initially set some limits which we will adjust as needed to ensure fairness. If you need to exceed these limits, please email the directors
+In order to allow members to communicate with eachother their intentions for using the space (to avoid dissapointments when travelling to find the space is at capacity), a booking system has been implemented. 
+
+The booking system is available at `https://booking.ehlab.uk/ <https://booking.ehlab.uk/>`_ and you can login with your normal Hacklab username and password. You can reset this password at `https://admin.ehlab.uk/ <https://admin.ehlab.uk>`. 
+
+To ensure access to the lab is fairly available to all members, some limits have been set. If you believe you need to exceed these limits, contact the directors who can provide exceptions reviewed on a case-by-case basis. 
 
 - You can only book a slot within the next two weeks
 - You are limited to a maximum of 10 hours of future reservations per week. This ensures fair use by preventing large blocks of bookings. As your bookings pass you can book more future slots, up to the 10 hour maximum.
 - You can only book 50 hours per month in total
-- Bookings have a gap between them to reduce exposure risk
 
-We have set a capacity on each room which must be respected to ensure 2m social distancing
+Each room has a maximum safe capacity which must be respected to ensure 2m social distancing:
 
 - G1 (Main space) - Two people with access maintained for one person to use the kitchen/shop or pickup mail/printing at any time
-- G2 (Laser cutting) - Single occupancy only
+- G2 (Laser cutting) - Individual occupancy only (or two people from one household/support bubble)
 - G8 (Workshop) - Two people. Please note in booking if you need any specific machines to help coordinate
 - G11 (Storage, 3D printers and servers) - Single occupancy with access to storage area for one additional person. When 3D printing, please don't stay longer than necessary. If you need access to the store, knock first due to limited space.
-- G14 (Electronics) - Single occupancy only
+- G14 (Electronics) - Individual occupancy only (or two people from one household/support bubble)
 
-All spaces must be booked with the exception for necessary access to the kitchen, shop, printing, mail or storage.
+All spaces must be booked with the exception for necessary/transient access to the kitchen, shop, printing, mail or storage.
 
 For G1 and G8 we recognise that members who are at higher risk may require exclusive access to the room. You may book both areas if this is required although please note that access to the kitchen/shop may be required by other users. If you need an additional quota to do this then please let the directors know.
 
@@ -124,9 +99,9 @@ Rules:
 
 - Wear a face covering on the premises at all times, unless you have a medical exemption. This includes within Summerhall corridors and communal areas. The rule applies within the work areas, even with exclusive use, to ensure the safety for the next user. 
 - Sanitise or wash your hands on arrival. Hand sanitiser is provided, and soap and hot water are available in the G1 kitchen.
-- Use your token on all doors, even if they are on the snib. This allows us to log your visit for contact tracing. 
+- Use your token on all doors, even if they are on the snib. This logs your visit to enable contact tracing if required.
 - Keep 2m from other users at all times unless they are a member of your household.
-- Open windows or turn on the G8 fan to ensure rooms are well ventilated.
+- Open windows and turn on the ventilation fans (available in G1 and G8) to ensure rooms are well ventilated.
 - Please knock and stand back from a door if you need access to another room (e.g. for a tool or accessing storage). Leave enough time for the user to answer before entering
 - Use single use or personal PPE where possible. Disposable earplugs are provided and all users may take one pair of safety glasses for their personal use (please keep in your storage box). Please contact the directors regarding Welding operations or the Grinding shields for a specific risk assessment and safe cleaning procedure.
 - Do not stay beyond your booking
@@ -135,38 +110,40 @@ Rules:
 
 Guidance:
 
-- Check your work area is clean before working. Cleaning products are provided if you wish to use them before starting work. Please email the directors if the place is untidy or unclean with photos if possible. This helps us chase the right people. 
+- Check your work area is clean before working. Cleaning products are provided if you wish to use them before starting work. Please email the directors if the area you have booked is untidy or unclean (with photos if possible). This helps us ensure fair accountability. 
 - If someone without a booking is using the area, please safely ask them to clear up and leave and inform the directors.
 - If you require the toilet, ensure single occupancy and wash hands thoroughly after use
 - Regularly sanitise or wash your hands during the visit
-- Any waste, especially where it may be contaminated with bodily fluids (e.g. tissues, paper towels, bottles and cans) must be placed in the bins. Gloves and a mask should be work when emptying bins and hands thoroughly cleaned afterwards
-- Avoid touching your face or face mask
+- Any waste, especially where it may be contaminated with bodily fluids (e.g. tissues, paper towels, bottles and cans) must be placed in the bins. Gloves and a mask should be worn when emptying bins and hands thoroughly cleaned afterwards
+- Avoid touching your face or face mask unnecessarily
 - Doors can be left open to increase ventilation and air the room while tidying
 - Leave plenty of time to clean and tidy your work area
 - Consider installing the Protect Scotland App on your phone.
 
 In An Emergency
 ^^^^^^^^^^^^^^^
-- If you need to give first aid to another user, gloves and a mask must be worn. If possible, you should help the casualty to treat themselves while maintaining a distance. All accidents or illness must be reported immediately to the directors.
+- If you need to give first aid to another user, gloves and a mask must be worn. If possible, you should help the casualty to treat themselves while maintaining a distance. All incidents must be reported immediately to the directors.
 - In the event of a fire, please exit the building promptly by the nearest fire exit. Maintain 2m social distancing at the muster point
 
 Please consider the additional risks of lone working and plan accordingly. We advise ensuring that someone knows when you are using the Hacklab and checking in with them when complete.
 
 After Your Visit
 ^^^^^^^^^^^^^^^^
-If you develop COVID-19 symptoms in the 10 days following your visit you must email the directors to enable contact tracing to take place. This is in addition to carrying out the notifications to NHS Test and Trace to enable us to take a proactive approach.
+If you develop COVID-19 symptoms in the 10 days following your visit you must email the directors to enable contact tracing to take place: You should also contact the NHS. 
 
 Enforcement
------------------
-We hope that all members will abide by these rules as they are designed to keep you and other members of the Hacklab community safe. We understand that guidance may change at short notice and behaviour change is hard so mistakes will be made. We hope minor issues can be dealt with by looking out for each other and reminding others to stay safe. In the event of more serious or repeated rule-breaking, the directors will be forced to take action to comply with our legal obligations and ensure we may keep the lab open.
+-----------
+It is forseeable that in some circumstances (perhaps due to carelessness, ignorance of the risks, or other factors), members may sometimes fall short of the expected standards of behaviour and cleanliness required to keep the Hacklab a safe space. 
+
+In light of this, the following procedures have been developed. It is important to note that these are not intended to punish anybody, and instead are designed to ensure the safety of the rest of the membership and keep the Hacklab COVID-free.
 
 Minor Issues
 ^^^^^^^^^^^^
-We hope minor issues can be dealt with by way of a reminder from other users
+We hope minor issues can be dealt with by way of an informal reminder from other users without any escalation.
 
 Examples:
 
-- Forgetting to wear a mask unless exempt
+- Neglecting to wear a mask (unless exempt)
 - Entering a room at capacity
 - Hygiene issues
 - Minor social distancing failures (while wearing masks)
@@ -174,19 +151,17 @@ Examples:
 What to do:
 
 - In the first instance, remind other users of the expectations in this policy from a safe distance.
-- Inform the directors of refusal or continued breaches
+- Inform the directors of refusal or continued breaches, or if you feel uncomfortable / unsafe.
 
 Moderate Breaches
 ^^^^^^^^^^^^^^^^^
-We operate a three-strikes policy with increasing severity. If you find issues such as housekeeping and tidiness when you arrive at your booking or if someone else is using the space, please email the directors with a picture so we can check who was responsible.
+We operate a three-strikes policy with increasing severity. If you find issues such as housekeeping and tidiness when you arrive at your booking or if someone else is using the space, please email the directors (with photographs if possible).
 
 Examples:
 
 - Repeated minor breaches
-- Failure to use the booking system
+- Refusal to use the booking system
 - Next user finds room untidy/unclean
-- Leaving the premises unsecured (e.g. closing windows at end of the booking)
-- Failure to follow government guidance (e.g. travel restrictions)
 
 What to do:
 
@@ -208,7 +183,6 @@ Examples:
 
 - Blatant refusal to comply with COVID policies (e.g. large groups using the lab, parties, putting others in immediate harm)
 - Using the lab with COVID symptoms or while you should be isolating
-- Breaches of COVID laws
 - Violence, abuse or harassment of other members or Summerhall staff/residents
 - Intentional endangerment of others 
 
@@ -222,4 +196,4 @@ What the directors will do:
 - Temporarily suspend access
 - Investigate the situation and interview those concerned
 - Take appropriate action
-- On return, conditions may be issued to ensure improved behaviour. Continued non-compliance may result in termination of membership.
+- On return, conditions may be issued to ensure improved behaviour.


### PR DESCRIPTION
I've done a quick pass over the COVID-19 policy to remove any copy-pasting of law/NHS guidance (instead linking/referencing the actual guidance where it makes sense) and to remove a lot of the verbosity associated with "formal" policy. I think a lot of the corporate-style furniture really clouds the intent of the policy, which I think is counter to having a policy that's simple and easy to understand by members. 

I've also made some changes to what should happen in Tier 3 / 4 based on _my reading_ of the guidance supplied by government. I couldn't find anything in my reading of the guidance that suggests Hacklab is required by law to close under tier 4, or that only companies with a CNI excemption are permitted to remain open. 

The bits I've rewritten, I've tried to approach it from the perspective that we should try and continue to facilitate member access to the space if they deem it necessary, but we should do this in a way which keeps members as safe as possible. This means providing the tools for members to use to communicate intent (booking system, etc) and expecting members to do the right thing. 

I've also rewritten a bit of the enforcement section to highlight that it is _not_ punitive, and instead is intended to keep the lab a safe space for all members. 

Opinions? I expect this would need a few more changes before it were to get merged, and I'm sure I've missed a few things. 